### PR TITLE
Updated `org.reflections::reflections` version to `0.9.9`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.9-RC1</version>
+            <version>0.9.9</version>
         </dependency>
 
         <!--Dependency Injection-->


### PR DESCRIPTION
Java 8 does not like `org.reflections::reflections` versions less than `0.9.9`.
